### PR TITLE
Hotfix 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2025-12-08
+
+* [PR-23](https://github.com/itk-dev/dokk1gh/pull/23)
+  Added cap on visitor last name length
+
 ## [1.6.0] - 2025-11-11
 
 * [PR-18](https://github.com/itk-dev/dokk1gh/pull/18)
@@ -36,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Security update.
 
-[Unreleased]: https://github.com/itk-dev/dokk1gh/compare/1.6.0...HEAD
+[Unreleased]: https://github.com/itk-dev/dokk1gh/compare/1.6.1...HEAD
+[1.6.1]: https://github.com/itk-dev/dokk1gh/compare/1.6.0...1.6.1
 [1.6.0]: https://github.com/itk-dev/dokk1gh/compare/1.5.0...1.6.0
 [1.5.0]: https://github.com/itk-dev/dokk1gh/releases/tag/1.5.0

--- a/src/Service/AeosHelper.php
+++ b/src/Service/AeosHelper.php
@@ -6,6 +6,8 @@ use App\Entity\Code;
 use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
+use function Symfony\Component\String\u;
+
 final readonly class AeosHelper
 {
     public function __construct(
@@ -55,6 +57,11 @@ final readonly class AeosHelper
             }
         }
         $visitorName = trim((string) $visitorName);
+        // AEOS says: Visitor.lastName: size must be between 1 and 50
+        $visitorName = u($visitorName)->slice(0, 50)->toString();
+        if (u($visitorName)->length() < 1) {
+            $visitorName = uniqid();
+        }
 
         $visitor = $this->aeosService->createVisitor([
             'UnitId' => $aeosContactPerson->UnitId,


### PR DESCRIPTION
<https://leantime.itkdev.dk/_#/tickets/showTicket/6151>

Adds cap on visitor last name length. AEOS reported

> 71-Add visitor failed : ConstraintViolation Errors occured:
> -Visitor.lastName: size must be between 1 and 50